### PR TITLE
`getPage()`: Encode name before adding it to the url

### DIFF
--- a/wikimediaApi.js
+++ b/wikimediaApi.js
@@ -33,7 +33,7 @@ function getPage(name, callback) {
   const API = WIKI_ENDPOINT + 'api.php';
   // TODO: string builder? what is risk of injection attack?
   // DO this: https://www.valentinog.com/blog/url/
-  let request = API + '?action=parse&prop=wikitext&format=json&page=' + name
+  let request = API + '?action=parse&prop=wikitext&format=json&page=' + encodeURIComponent(name)
   log.debug(`requesting: ${request}`);
   https.get(request, res => {
     res.setEncoding('utf-8');


### PR DESCRIPTION
Otherwise, if the name contains special characters (like `&`), then it will not be retrieved.